### PR TITLE
fixed goarch names

### DIFF
--- a/artifacts/artifacts.go
+++ b/artifacts/artifacts.go
@@ -29,7 +29,7 @@ func DownloadArtifacts() (map[string]string, error) {
 					return "x86_64-unknown-linux-gnu"
 				} else if goos == "darwin" && goarch == "arm64" { // Apple M1
 					return "aarch64-apple-darwin"
-				} else if goos == "darwin" && goarch == "x86_64" {
+				} else if goos == "darwin" && goarch == "amd64" {
 					return "x86_64-apple-darwin"
 				}
 				return ""
@@ -44,7 +44,7 @@ func DownloadArtifacts() (map[string]string, error) {
 					return "x86_64-unknown-linux-gnu"
 				} else if goos == "darwin" && goarch == "arm64" { // Apple M1
 					return "x86_64-apple-darwin-portable"
-				} else if goos == "darwin" && goarch == "x86_64" {
+				} else if goos == "darwin" && goarch == "amd64" {
 					return "x86_64-apple-darwin"
 				}
 				return ""


### PR DESCRIPTION
modified the references `goarch`s from `x86_64` to `amd64` which is what `go version` returns in my x86_64 machine (and was preventing from finding the binary to download).

note that I'm running an old macOS 10.15 so this might have changed for newer macs (that are still Intel).